### PR TITLE
Add babel-core to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "humanmade",
   "license": "MIT",
   "devDependencies": {
+    "babel-core": "^6.0.0",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",


### PR DESCRIPTION
This fixes an npm warning which keeps babel-loader from working properly.

See #23 